### PR TITLE
fix: stop postgres service

### DIFF
--- a/tasks/util/create_additional_databases.yml
+++ b/tasks/util/create_additional_databases.yml
@@ -21,3 +21,8 @@
     loop_var: additional_db
   # Suppress logging to avoid dumping the credentials to the shell
   no_log: true
+
+- name: Ensure Postgres is stopped
+  ansible.builtin.service:
+    name: "{{ devture_postgres_identifier }}"
+    state: stopped

--- a/tasks/util/create_additional_databases.yml
+++ b/tasks/util/create_additional_databases.yml
@@ -22,7 +22,9 @@
   # Suppress logging to avoid dumping the credentials to the shell
   no_log: true
 
-- name: Ensure Postgres is stopped
+- when: "devture_postgres_ensure_started_result.changed | bool"
+  name: Ensure Postgres is stopped
   ansible.builtin.service:
     name: "{{ devture_postgres_identifier }}"
     state: stopped
+  

--- a/tasks/util/create_additional_databases.yml
+++ b/tasks/util/create_additional_databases.yml
@@ -5,9 +5,9 @@
     name: "{{ devture_postgres_identifier }}"
     state: started
     daemon_reload: true
-  register: devture_postgres_service_start_result
+  register: devture_postgres_ensure_started_result
 
-- when: "devture_postgres_service_start_result.changed | bool"
+- when: "devture_postgres_ensure_started_result.changed | bool"
   name: Wait a bit, so that Postgres can start
   ansible.builtin.wait_for:
     timeout: "{{ devture_postgres_additional_databases_postgres_start_wait_timeout_seconds }}"


### PR DESCRIPTION
Add missing `stop` task. 
When running `--tags=setup-all` or something equivalent this would cause the `postgres` service to stay up and running. I'm not able to test all the 'import' cases in the other util files so there might be other tree-paths out there that leave a dangling process. Maybe it's even better to add this task to the `main.yml`?

Anyway, need to ensure all process are killed when the user didn't ask for them to stay up.