### PR TITLE
Improve error handling while importing

### DIFF
--- a/tasks/import_postgres.yml
+++ b/tasks/import_postgres.yml
@@ -80,7 +80,7 @@
       {{ 'gunzip |' if server_path_postgres_dump.endswith('.gz') else '' }}
       grep -vE '{{ devture_postgres_import_roles_ignore_regex }}' |
       grep -vE '{{ devture_postgres_import_databases_ignore_regex }}' |
-      psql -v ON_ERROR_STOP=1 -h {{ devture_postgres_identifier }} --dbname={{ postgres_default_import_database }}"
+      psql -b -v ON_ERROR_STOP=1 -h {{ devture_postgres_identifier }} --dbname={{ postgres_default_import_database }}"
   tags:
     - skip_ansible_lint
 

--- a/tasks/import_postgres.yml
+++ b/tasks/import_postgres.yml
@@ -76,7 +76,7 @@
       --mount type=bind,src={{ server_path_postgres_dump }},dst=/{{ server_path_postgres_dump | basename }},ro
       --entrypoint=/bin/sh
       {{ devture_postgres_container_image_latest }}
-      -c "cat /{{ server_path_postgres_dump | basename }} |
+      -c "set -o pipefail && cat /{{ server_path_postgres_dump | basename }} |
       {{ 'gunzip |' if server_path_postgres_dump.endswith('.gz') else '' }}
       grep -vE '{{ devture_postgres_import_roles_ignore_regex }}' |
       grep -vE '{{ devture_postgres_import_databases_ignore_regex }}' |


### PR DESCRIPTION
My dump file had incorrect permissions, but instead of failing, the import did not show an error.
When running the command manually and without _--logdriver=none_, the _sed_ showed an permission denied error.
Instead of using _--logdriver=none_ I would prefer to tell psql to only show errors (_-b_).